### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=FaBo<info@fabo.io>
 maintainer=Akira Sasaki<akira@fabo.io>
 sentence=A library for FaBo PWM.
 paragraph=PCA9685 is I2C PWM.
-category=PWM
+category=Signal Input/Output
 url=https://github.com/FaBoPlatform/FaBoPWM-PCA9685-Library
 architectures=avr,esp32


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'PWM' in library FaBo PWM PCA9685 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format